### PR TITLE
docs: update documentation link to new URL

### DIFF
--- a/templates/discloud.config.ejs
+++ b/templates/discloud.config.ejs
@@ -1,2 +1,2 @@
-# https://docs.discloudbot.com/discloud.config
+# https://docs.discloud.com/en/configurations/discloud.config
 <% for (const prop in props) { if (props[prop] !== null && props[prop] !== undefined) { %><%= prop %>=<%= props[prop] %><%- "\n" %><% }} %>

--- a/test/templates/discloudconfig.test.mjs
+++ b/test/templates/discloudconfig.test.mjs
@@ -14,7 +14,7 @@ suite("template DiscloudConfig test", async () => {
       String: "String",
     };
 
-    const expected = "# https://docs.discloudbot.com/discloud.config\nNumber=0\nEmptyString=\nString=String\n";
+    const expected = "# https://docs.discloud.com/en/configurations/discloud.config\nNumber=0\nEmptyString=\nString=String\n";
 
     const rendered = await renderFile(templateFilePath, { props }, { async: true });
 


### PR DESCRIPTION
Updated the discloud.config documentation link from docs.discloudbot.com to docs.discloud.com/en/configurations/discloud.config as the documentation has been updated.